### PR TITLE
Add support for keras models for outputs

### DIFF
--- a/pyESN.py
+++ b/pyESN.py
@@ -271,4 +271,6 @@ class ESN():
                 outputs[n + 1, :] = self.keras_model.predict(
                     np.expand_dims(np.concatenate([states[n+1, :], inputs[n+1, :]]), axis=0))
 
+        if self.keras_model is None:
+            outputs[1:] = self.out_activation(outputs[1:])
         return self._unscale_teacher(outputs[1:])

--- a/testing.py
+++ b/testing.py
@@ -1,5 +1,6 @@
 import unittest
 import numpy as np
+import keras
 
 from pyESN import ESN
 
@@ -138,6 +139,17 @@ class InitArguments(unittest.TestCase):
             prediction_t = esn.predict(Xp)
             self.assertEqual(prediction_tr.shape, (N_samples, N_out))
             self.assertEqual(prediction_t.shape, (N_samples, N_out))
+
+    def test_keras_model(self):
+        """try the keras_model parameter"""
+        model = keras.models.Sequential()
+        model.add(keras.layers.Dense(units=200, activation='relu', input_dim=N+N_in))
+        model.add(keras.layers.Dense(units=N_out, activation='linear'))
+        model.compile(loss='mae', optimizer='adagrad')
+
+        esn = ESN(N_in, N_out, n_reservoir=N, keras_model=model)
+        esn.fit(self.X, self.y, epochs=20, verbose=0)
+        esn.predict(self.Xp)
 
 
 class Performance(unittest.TestCase):


### PR DESCRIPTION
To follow up on #5, here's what I worked out: Keras layer building turned out to be too much of a challenge for me, so I modified pyESN to optionally accept a Keras model as an input. Now, instead of learning linear weights to map readouts to outputs, it trains the Keras model to do so. If you don't think that this is appropriate to be included in the main code, that's totally fine. I just wanted to share what I did.

Here's [mackey.ipynb,](https://github.com/cknd/pyESN/files/2203404/mackey.txt) modified to use my new functionality. The performance is worse, but it shows how it works. (GitHub won't let me upload `.ipynb,` so I changed the file extension to `.txt`. Just change it back to view.)

I added a new test, but it would only catch the most extreme errors. I wasn't sure of what to include in a more useful test. ~~The freq_gen performance test fails both before and after my changes.~~

Also, I'd like to add a `.gitignore`. Should I open a new PR or can I just add it to this one?